### PR TITLE
Fix of tank fullness level drawing

### DIFF
--- a/fluid_tanks/init.lua
+++ b/fluid_tanks/init.lua
@@ -135,7 +135,7 @@ local function create_tank_node(tankname, def, fluid_name)
 
 	minetest.register_node(tankname, {
 		description = desc,
-		drawtype = "glasslike_framed_optional",
+		drawtype = "glasslike_framed",
 		paramtype = "light",
 		paramtype2 = "glasslikeliquidlevel",
 		is_ground_content = false,


### PR DESCRIPTION
I have a bug in luanti 5.15.0 with VoxeLibre 0.91.2 and current master branch of melterns. Fluid level is not drawn properly in fluid tanks.
Trased problem to here. Probably something changed in luanti, but don't know when.
This fixes my case.
Do I have to test any other use-case before merge?